### PR TITLE
Optimised overlay render logic

### DIFF
--- a/lib/step_widget_builder.dart
+++ b/lib/step_widget_builder.dart
@@ -52,7 +52,7 @@ class _StepWidgetBuilder {
 
     /// The distance on the right side is very large, it is more beautiful on
     /// the right side
-    if (rightArea > 0.8 * topArea && rightArea > 0.8 * bottomArea) {
+    if (rightArea > 0.8 * topArea && rightArea > 0.8 * bottomArea && rightArea > leftArea) {
       position.left = offset.dx + width + 16;
       position.top = offset.dy - 4;
       position.bottom = null;
@@ -61,7 +61,7 @@ class _StepWidgetBuilder {
     }
 
     /// The distance on the left is large, it is more beautiful on the left side
-    if (leftArea > 0.8 * topArea && leftArea > 0.8 * bottomArea) {
+    if (leftArea > 0.8 * topArea && leftArea > 0.8 * bottomArea && leftArea > rightArea) {
       position.right = rightArea + width + 16;
       position.top = offset.dy - 4;
       position.bottom = null;


### PR DESCRIPTION
Currently the `IntroStepBuilder` renders overlay on the left side even when there is more space on the right, because the `getOverlayPosition` function inside `_StepWidgetBuilder` verifies if there is more space on the sides compared to top and bottom spaces but it doesn't exactly calculate which side has more space.

Before:

https://github.com/user-attachments/assets/00e861ee-42b5-463f-bd6b-44d9bf40f198


After:

https://github.com/user-attachments/assets/f5ce0d88-4888-42a7-9403-af5ee104f612


to reproduce the issue add padding to the right above centre widget here in the example

https://github.com/minaxorg/flutter_intro/blob/c73af8c1e0f9406c4a4c8dd27b2dd20721f49d99/example/lib/group_usage.dart#L4-L12

Like this:
```dart
      appBar: AppBar(),
      body: Padding(
        padding: const EdgeInsets.only(right: 100),
        child: Center(
          child: Column(
``` 
